### PR TITLE
Duplicate key support

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,13 @@ function _parse(stream, ptr) {
                     lastbrk = undefined;  // Ignore this sentry if it's the second bracketed expression
                 }
                 else {
-                    deserialized[laststr] = string;
+                    if (laststr in deserialized) {
+                        if (!Array.isArray(deserialized[laststr])) deserialized[laststr] = [deserialized[laststr]];
+                        deserialized[laststr].push(string);
+                    }
+                    else {
+                        deserialized[laststr] = string;
+                    }
                 }
             }
             c = STRING;  // Force c == string so lasttok will be set properly.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,9 @@
   "version": "0.0.2",
   "private": false,
   "scripts": {
-    "start": "node vdf"
+    "test": "nodeunit test.js"
   },
-  "dependencies": {
-    "util": "*"
-    },
-  "readmeFilename": "README.md",
+  "dependencies": {},
   "description": "A port of steamodd's vdf.py to node.js.",
   "main": "index.js",
   "repository": {
@@ -21,5 +18,12 @@
     "vdf"
   ],
   "author": "Rob Jackson",
-  "license": "ISC"
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/RJacksonm1/node-vdf/issues"
+  },
+  "homepage": "https://github.com/RJacksonm1/node-vdf",
+  "devDependencies": {
+    "nodeunit": "^0.9.1"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -67,6 +67,14 @@ var UNQUOTED_VDF = "\n\
     } \n\
     ",
 
+    DUPLICATE_KEYS_VDF = " \n\
+    node { \n\
+        \"key\" \"value\" \n\
+        key \"value2\" \n\
+        \"key\" value3 \n\
+    } \n\
+    ",
+
     /* Expectations */
     EXPECTED_UNQUOTED_VDF = {
         "node": {
@@ -96,7 +104,13 @@ var UNQUOTED_VDF = "\n\
                 },
             "key4": "value"
             }
-        };
+        },
+    EXPECTED_DUPLICATE_KEYS_VDF = {
+        "node": {
+            "key": ["value", "value2", "value3"]
+        }
+    };
+
 
 /* Serialization */
 var SIMPLE_OBJ = EXPECTED_UNQUOTED_VDF,
@@ -170,7 +184,8 @@ exports.deserialization = {
     test_macro_quoted: function (test) { test.equal(JSON.stringify(EXPECTED_MACRO_QUOTED_VDF), JSON.stringify(vdf.parse(MACRO_QUOTED_VDF))); test.done(); },
     test_comment_quoted: function (test) { test.equal(JSON.stringify(EXPECTED_COMMENT_QUOTED_VDF), JSON.stringify(vdf.parse(COMMENT_QUOTED_VDF))); test.done(); },
     test_subnode_quoted: function (test) { test.equal(JSON.stringify(EXPECTED_SUBNODE_QUOTED_VDF), JSON.stringify(vdf.parse(SUBNODE_QUOTED_VDF))); test.done(); },
-    test_mixed: function (test) { test.equal(JSON.stringify(EXPECTED_MIXED_VDF), JSON.stringify(vdf.parse(MIXED_VDF))); test.done(); }
+    test_mixed: function (test) { test.equal(JSON.stringify(EXPECTED_MIXED_VDF), JSON.stringify(vdf.parse(MIXED_VDF))); test.done(); },
+    test_duplicate_keys: function (test) { test.equal(JSON.stringify(EXPECTED_DUPLICATE_KEYS_VDF), JSON.stringify(vdf.parse(DUPLICATE_KEYS_VDF))); test.done(); }
 };
 
 exports.serialization = {


### PR DESCRIPTION
For some reason, VDF/KeyValue supports duplicate keys. I added support to turn them into arrays (you can see an example in the updated test.js)

I also fixed up the package.json a little. `npm start` doesn't do anything for a library, `util` is a stdlib package (included with node) so we don't need it in the dependencies, and if you include nodeunit in your devDependencies then you can run the tests with `npm test`.
